### PR TITLE
feat: add intuitive single-key shortcuts for drawing tools

### DIFF
--- a/src/renderer/app_page/components/Application.js
+++ b/src/renderer/app_page/components/Application.js
@@ -373,6 +373,45 @@ const Application = (settings) => {
 
         break;
       }
+      case 'p': {
+        // Shortcut: P = Pen tool (toggle between pen and fadepen)
+        if (activeTool === 'pen') {
+          handleChangeTool('fadepen');
+        } else {
+          handleChangeTool('pen');
+        }
+        break;
+      }
+      case 'r': {
+        // Shortcut: R = Rectangle tool
+        handleChangeTool('rectangle');
+        break;
+      }
+      case 'a': {
+        // Shortcut: A = Arrow tool (uniform width)
+        handleChangeTool('flat_arrow');
+        break;
+      }
+      case 'l': {
+        // Shortcut: L = Line tool
+        handleChangeTool('line');
+        break;
+      }
+      case 'o': {
+        // Shortcut: O = Oval tool
+        handleChangeTool('oval');
+        break;
+      }
+      case 'h': {
+        // Shortcut: H = Highlighter tool
+        handleChangeTool('highlighter');
+        break;
+      }
+      case 't': {
+        // Shortcut: T = Text tool
+        handleChangeTool('text');
+        break;
+      }
       case 'e': {
         handleChangeTool('eraser');
         break;

--- a/src/renderer/app_page/components/components/ToolBar.js
+++ b/src/renderer/app_page/components/components/ToolBar.js
@@ -191,27 +191,27 @@ const ToolBar = ({
   const renderToolTitle = (tool) => {
     switch (tool) {
       case "pen":
-        return "Pen";
+        return "Pen (P)";
       case "fadepen":
-        return "Fade Pen";
+        return "Fade Pen (P)";
       case "arrow":
         return "Arrow";
       case "flat_arrow":
-        return "Flat Arrow";
+        return "Flat Arrow (A)";
       case "rectangle":
-        return "Rectangle";
+        return "Rectangle (R)";
       case "oval":
-        return "Oval";
+        return "Oval (C)";
       case "line":
-        return "Line";
+        return "Line (L)";
       case "text":
-        return "Text";
+        return "Text (T)";
       case "highlighter":
-        return "Highlighter";
+        return "Highlighter (H)";
       case "laser":
         return "Laser";
       case "eraser":
-        return "Eraser";
+        return "Eraser (E)";
       default:
         return "Tool";
     }


### PR DESCRIPTION
Add keyboard shortcuts for quick tool switching during drawing mode:

- P: Pen (press again to toggle to Fade Pen)
- R: Rectangle
- A: Flat Arrow (uniform width)
- O: Oval
- L: Line
- H: Highlighter
- T: Text

Existing shortcuts (E for Eraser, X for color swap, digits 1-8) remain unchanged.

Toolbar tooltips now display shortcut hints on hover, e.g. "Pen (P)", "Rectangle (R)", helping users discover shortcuts.

Files changed:

https://github.com/user-attachments/assets/d6b1ebd3-5067-4d82-aa28-8dd98d3a8988


- src/renderer/app_page/components/Application.js
- src/renderer/app_page/components/components/ToolBar.js