### PR TITLE
Add pen smoothing setting

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -120,6 +120,10 @@ const schema = {
     type: 'boolean',
     default: true
   },
+  pen_smoothing: {
+    type: 'boolean',
+    default: true
+  },
   app_icon_color: {
     type: 'string',
     default: 'default'
@@ -690,6 +694,7 @@ ipcMain.handle('get_settings', () => {
     show_tool_bar: store.get('show_tool_bar'),
     show_drawing_border: store.get('show_drawing_border'),
     show_cute_cursor: store.get('show_cute_cursor'),
+    pen_smoothing: store.get('pen_smoothing'),
     tool_bar_x: store.get('tool_bar_x'),
     tool_bar_y: store.get('tool_bar_y'),
     tool_bar_active_tool: store.get('tool_bar_active_tool'),
@@ -784,6 +789,7 @@ ipcMain.handle('get_configuration', () => {
 
     show_drawing_border:                      store.get('show_drawing_border'),
     show_cute_cursor:                         store.get('show_cute_cursor'),
+    pen_smoothing:                            store.get('pen_smoothing'),
     swap_colors_indexes:                      store.get('swap_colors_indexes'),
     fade_disappear_after_ms:                  store.get('fade_disappear_after_ms'),
     fade_out_duration_time_ms:                store.get('fade_out_duration_time_ms'),
@@ -900,6 +906,16 @@ ipcMain.handle('set_show_cute_cursor', (_event, value) => {
   return null;
 });
 
+ipcMain.handle('set_pen_smoothing', (_event, value) => {
+  rawLog('Setting pen smoothing:', value)
+
+  store.set('pen_smoothing', value)
+
+  refreshSettingsInRenderer();
+
+  return null;
+});
+
 ipcMain.handle('set_swap_colors', (_event, value) => {
   rawLog('Setting swap colors:', value)
 
@@ -969,8 +985,14 @@ ipcMain.handle('set_disable_toolbar_in_pointer_mode', (_event, value) => {
 
 function refreshSettingsInRenderer() {
   mainWindow.webContents.send('refresh_settings', {
+    whiteboard_color:        store.get('whiteboard_color'),
+    whiteboard_layout:       store.get('whiteboard_layout'),
+    whiteboard_opacity:      store.get('whiteboard_opacity'),
+    whiteboard_style:        store.get('whiteboard_style'),
+    whiteboard_spacing:      store.get('whiteboard_spacing'),
     show_drawing_border:     store.get('show_drawing_border'),
     show_cute_cursor:        store.get('show_cute_cursor'),
+    pen_smoothing:           store.get('pen_smoothing'),
     swap_colors_indexes:     store.get('swap_colors_indexes'),
   })
 }

--- a/src/renderer/app_page/components/Application.js
+++ b/src/renderer/app_page/components/Application.js
@@ -85,6 +85,7 @@ const Application = (settings) => {
   const initialWhiteboardSpacing = settings.whiteboard_spacing
   const initialShowDrawingBorder = settings.show_drawing_border
   const initialShowCuteCursor = settings.show_cute_cursor
+  const initialPenSmoothing = settings.pen_smoothing
   const initialToolbarDefaultBrush = settings.tool_bar_default_brush
   const initialToolbarDefaultFigure = settings.tool_bar_default_figure
   const initialToolbarCollapsed = settings.tool_bar_collapsed
@@ -150,6 +151,7 @@ const Application = (settings) => {
   const [isFadeDrawing, setIsFadeDrawing] = useState(false);
   const [showDrawingBorder, setShowDrawingBorder] = useState(initialShowDrawingBorder);
   const [showCuteCursor, setShowCuteCursor] = useState(initialShowCuteCursor);
+  const [penSmoothing, setPenSmoothing] = useState(initialPenSmoothing);
   const [mainColorIndex, setMainColorIndex] = useState(initialMainColorIndex);
   const [secondaryColorIndex, setSecondaryColorIndex] = useState(initialSecondaryColorIndex);
   const [toastInfo, setToastInfo] = useState(null);
@@ -1242,7 +1244,7 @@ const Application = (settings) => {
       if (activeTool === 'fadepen') {
         const currentFigure = allFadeFigures.at(-1);
 
-        if (colorList[currentFigure.colorIndex].name !== 'color_rainbow') {
+        if (penSmoothing && colorList[currentFigure.colorIndex].name !== 'color_rainbow') {
           currentFigure.points = [...filterClosePoints(currentFigure.points, currentFigure.widthIndex)];
         }
 
@@ -1253,7 +1255,7 @@ const Application = (settings) => {
       if (activeTool === 'pen') {
         const currentFigure = allFigures.at(-1);
 
-        if (colorList[currentFigure.colorIndex].name !== 'color_rainbow') {
+        if (penSmoothing && colorList[currentFigure.colorIndex].name !== 'color_rainbow') {
           currentFigure.points = [...filterClosePoints(currentFigure.points, currentFigure.widthIndex)];
         }
 
@@ -1393,6 +1395,7 @@ const Application = (settings) => {
     setWhiteboardSpacing(newSettings.whiteboard_spacing);
     setShowDrawingBorder(newSettings.show_drawing_border);
     setShowCuteCursor(newSettings.show_cute_cursor);
+    setPenSmoothing(newSettings.pen_smoothing);
     setMainColorIndex(newSettings.swap_colors_indexes[0]);
     setSecondaryColorIndex(newSettings.swap_colors_indexes[1]);
   };

--- a/src/renderer/settings_page/components/Settings.js
+++ b/src/renderer/settings_page/components/Settings.js
@@ -54,6 +54,7 @@ const ShortcutRow = ({ title, description, hint, shortcut, onCheck, onChange, on
 const Settings = (config) => {
   const [showDrawingBorder, setShowDrawingBorder] = useState(config.show_drawing_border);
   const [showCuteCursor, setShowCuteCursor] = useState(config.show_cute_cursor);
+  const [penSmoothing, setPenSmoothing] = useState(config.pen_smoothing);
   const [appIconColor, setAppIconColor] = useState(config.app_icon_color);
   const [fadeDisappearAfterMs, setFadeDisappearAfterMs] = useState(config.fade_disappear_after_ms);
   const [fadeOutDurationTimeMs, setFadeOutDurationTimeMs] = useState(config.fade_out_duration_time_ms);
@@ -153,6 +154,13 @@ const Settings = (config) => {
     setShowCuteCursor(nextState);
 
     window.electronAPI.setShowCuteCursor(nextState);
+  };
+
+  const togglePenSmoothing = () => {
+    const nextState = !penSmoothing;
+    setPenSmoothing(nextState);
+
+    window.electronAPI.setPenSmoothing(nextState);
   };
 
   const toggleLaunch = () => {
@@ -388,6 +396,20 @@ const Settings = (config) => {
                     <div
                       className={`toggle ${showCuteCursor ? '' : 'active'}`}
                       onClick={toggleCuteCursor}
+                    ></div>
+                  </div>
+                </div>
+
+                <div className="settings-item">
+                  <div className="settings-item-info">
+                    <div className="settings-item-title">Smooth Pen Strokes</div>
+                    <div className="settings-item-description">Turn off to keep raw strokes</div>
+                  </div>
+
+                  <div className="settings-item-control">
+                    <div
+                      className={`toggle ${penSmoothing ? 'active' : ''}`}
+                      onClick={togglePenSmoothing}
                     ></div>
                   </div>
                 </div>

--- a/src/renderer/settings_page/preload.js
+++ b/src/renderer/settings_page/preload.js
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   resetToOriginals: () => ipcRenderer.invoke('reset_to_originals'),
   setShowDrawingBorder: (value) => ipcRenderer.invoke('set_show_drawing_border', value),
   setShowCuteCursor: (value) => ipcRenderer.invoke('set_show_cute_cursor', value),
+  setPenSmoothing: (value) => ipcRenderer.invoke('set_pen_smoothing', value),
   setLaserTimeMs: (value) => ipcRenderer.invoke('set_laser_time', value),
   setAppIconColor: (value) => ipcRenderer.invoke('set_app_icon_color', value),
   setSwapColors: (value) => ipcRenderer.invoke('set_swap_colors', value),


### PR DESCRIPTION
## Summary
- Add a Smooth Pen Strokes setting, enabled by default
- Use the setting to control the existing width-based pen point filtering
- Keep raw pen/fade pen strokes when the setting is turned off

Refs #71

## Testing
- npm install
- set NODE_ENV=development&& .\node_modules\.bin\electron-forge.cmd start
- Manual test: verified the Settings page shows Smooth Pen Strokes
- Manual test: toggled Smooth Pen Strokes on/off and drew with Pen
- Manual test: toggled Smooth Pen Strokes on/off and drew with Fade Pen
- Manual test: verified Rainbow pen drawing still works